### PR TITLE
Fixed the Python unit tests

### DIFF
--- a/PyGMO/algorithm/__init__.py
+++ b/PyGMO/algorithm/__init__.py
@@ -583,9 +583,9 @@ def _sms_emoa_ctor(
     # We set the defaults or the kwargs
     arg_list = []
 
-    from PyGMO.util import HypervolumeValidation
+    from PyGMO.util import _HypervolumeValidation
     if hv_algorithm:
-        hv_algorithm = HypervolumeValidation.validate_hv_algorithm(
+        hv_algorithm = _HypervolumeValidation.validate_hv_algorithm(
             hv_algorithm)
         arg_list.append(hv_algorithm)
     arg_list.append(gen)
@@ -1025,9 +1025,9 @@ def _cstrs_co_evolution_ctor(
     """
     arg_list = []
     if original_algo is None:
-        original_algo = algorithm.jde()
+        original_algo = _algorithm.jde()
     if original_algo_penalties is None:
-        original_algo_penalties = algorithm.jde()
+        original_algo_penalties = _algorithm.jde()
     arg_list.append(original_algo)
     arg_list.append(original_algo_penalties)
     arg_list.append(pop_penalties_size)
@@ -1081,9 +1081,9 @@ def _cstrs_immune_system_ctor(
     arg_list = []
 
     if algorithm is None:
-        algorithm = algorithm.jde()
+        algorithm = _algorithm.jde()
     if algorithm_immune is None:
-        algorithm_immune = algorithm.jde()
+        algorithm_immune = _algorithm.jde()
     arg_list.append(algorithm)
     arg_list.append(algorithm_immune)
     arg_list.append(gen)
@@ -1124,9 +1124,9 @@ def _cstrs_core_ctor(
     """
     arg_list = []
     if algorithm is None:
-        algorithm = algorithm.jde()
+        algorithm = _algorithm.jde()
     if repair_algorithm is None:
-        repair_algorithm = algorithm.jde()
+        repair_algorithm = _algorithm.jde()
     arg_list.append(algorithm)
     arg_list.append(repair_algorithm)
     arg_list.append(gen)

--- a/PyGMO/test/__init__.py
+++ b/PyGMO/test/__init__.py
@@ -27,7 +27,7 @@ import unittest as _ut
 class _serialization_test(_ut.TestCase):
 
     def test_pickle(self):
-        from PyGMO import archipelago, island_list, problem_list, algorithm_list, problem
+        from PyGMO import archipelago, island_list, problem_list, algorithm_list, problem, algorithm
         import pickle
         from copy import deepcopy
         # We remove some problems that cannot be constructed without external
@@ -38,7 +38,6 @@ class _serialization_test(_ut.TestCase):
         for isl in island_list:
             for prob in prob_list:
                 for algo in algorithm_list:
-                    print(isl, type(prob()), type(algo()))
                     a = archipelago()
                     a.push_back(isl(algo(), prob(), 20))
                     a.push_back(isl(algo(), prob(), 20))

--- a/PyGMO/util/__init__.py
+++ b/PyGMO/util/__init__.py
@@ -142,7 +142,7 @@ def _hypervolume_compute(self, r=None, algorithm=None, *args, **kwargs):
         raise TypeError(
             "Incorrect combination of args/kwargs, type 'hypervolume.compute?' for usage")
 
-    r = _HypervolumeValidationlidation.handle_refpoint(self, r)
+    r = _HypervolumeValidation.handle_refpoint(self, r)
     args = []
     args.append(r)
     if algorithm:


### PR DESCRIPTION
This patch fixes some import errors, and use of "algorithm.jde()" where "algorithm" was not in the scope yet.

When you run:
```Python
from PyGMO import test
test.run_full_test_suite()
```
The tests should complete