### PR TITLE
Add Continuous Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ script:
     - make install
 
 after_success:
-    - PYTHONPATH=~/local/python LD_LIBRARY_PATH=$LD_LIBRARY_PATH:~/local/lib python -c "import PyGMO; print(PyGMO.__version__)"
+    - PYTHONPATH=~/local/python LD_LIBRARY_PATH=$LD_LIBRARY_PATH:~/local/lib:$TRAVIS_BUILD_DIR/../boost-trunk/lib python -c "import PyGMO; print(PyGMO.__version__)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ script:
     - make install
 
 after_success:
-    - PYTHONPATH=~/local/python LD_LIBRARY_PATH=~/local/lib python -c "import PyGMO; print(PyGMO.__version__)"
+    - PYTHONPATH=~/local/python LD_LIBRARY_PATH=$LD_LIBRARY_PATH:~/local/lib python -c "import PyGMO; print(PyGMO.__version__)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: cpp
-compiler: g++
+compiler: clang 
 before_install: 
     - sudo apt-get update -qq
     - sudo apt-get purge libboost*1.46*

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ compiler: g++
 before_install: 
     - sudo apt-get update -qq
     - sudo apt-get purge libboost*1.46*
-    - sudo apt-get install libboost1.48-all-dev
+    - sudo apt-get install libboost1.55-all-dev
 script:
     - mkdir build
     - cd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: cpp
+compiler: g++
+before_install: 
+    - sudo apt-get update -qq
+    - sudo apt-get purge libboost*1.46*
+    - sudo apt-get install libboost1.48-all-dev
+script:
+    - mkdir build
+    - cd build
+    - cmake ..
+    - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,10 @@ before_install:
 script:
     - mkdir build
     - cd build
-    - cmake .. -DENABLE_TESTS="ON" -DBUILD_PYGMO="on"
+    - cmake .. -DENABLE_TESTS="ON" -DBUILD_PYGMO="on" -DPYTHON_MODULES_DIR="~/local/python" -DCMAKE_INSTALL_PREFIX="~/local"
     - make -j 9
     - make test
     - make install
 
 after_success:
-    - python -c "import PyGMO; print(PyGMO.__version__)"
+    - PYTHONPATH=~/local/python LD_LIBRARY_PATH=~/local/lib python -c "import PyGMO; print(PyGMO.__version__)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,5 +15,10 @@ before_install:
 script:
     - mkdir build
     - cd build
-    - cmake ..
-    - make
+    - cmake .. -DENABLE_TESTS="ON" -DBUILD_PYGMO="on"
+    - make -j 9
+    - make test
+    - make install
+
+after_success:
+    - python -c "import PyGMO; print(PyGMO.__version__)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,15 @@ compiler: g++
 before_install: 
     - sudo apt-get update -qq
     - sudo apt-get purge libboost*1.46*
-    - sudo apt-get install libboost1.55-all-dev
+    # Build boost manually because the version on travis is too old
+    - wget --no-verbose --output-document=boost-trunk.tar.bz2 http://sourceforge.net/projects/boost/files/boost/1.55.0/boost_1_55_0.tar.bz2/download
+    - export BOOST_ROOT="$TRAVIS_BUILD_DIR/../boost-trunk"
+    - export CMAKE_MODULE_PATH="$BOOST_ROOT"
+    - mkdir -p $BOOST_ROOT
+    - tar jxf boost-trunk.tar.bz2 --strip-components=1 -C $BOOST_ROOT
+    - (cd $BOOST_ROOT; ./bootstrap.sh --with-libraries=system,thread,serialization)
+    - (cd $BOOST_ROOT; ./b2 threading=multi --prefix=$BOOST_ROOT -d0 install)
+    - sudo apt-get install libboost-dev
 script:
     - mkdir build
     - cd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
     - export CMAKE_MODULE_PATH="$BOOST_ROOT"
     - mkdir -p $BOOST_ROOT
     - tar jxf boost-trunk.tar.bz2 --strip-components=1 -C $BOOST_ROOT
-    - (cd $BOOST_ROOT; ./bootstrap.sh --with-libraries=system,thread,serialization)
+    - (cd $BOOST_ROOT; ./bootstrap.sh --with-libraries=system,thread,serialization,python)
     - (cd $BOOST_ROOT; ./b2 threading=multi --prefix=$BOOST_ROOT -d0 install)
     - sudo apt-get install libboost-dev
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
     - tar jxf boost-trunk.tar.bz2 --strip-components=1 -C $BOOST_ROOT
     - (cd $BOOST_ROOT; ./bootstrap.sh --with-libraries=system,thread,serialization,python)
     - (cd $BOOST_ROOT; ./b2 threading=multi --prefix=$BOOST_ROOT -d0 install)
-    - sudo apt-get install libboost-dev
+    - sudo apt-get install libboost-dev python-dev
 script:
     - mkdir build
     - cd build

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 PaGMO
 =====
 
-[![Join the chat at https://gitter.im/esa/pygmo](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/esa/pagmo?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Join the chat at https://gitter.im/esa/pygmo](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/esa/pagmo?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) 
+[![Build Status](https://travis-ci.org/esa/pagmo.svg?branch=master)](https://travis-ci.org/esa/pagmo)
 
 Parallel Global Multiobjective Optimizer (and its Python alter ego PyGMO) offers a
 user-friendly access to a wide array of global and local optimization algorithms and problems.


### PR DESCRIPTION
Added base Travis file and build badge in the README. You will have to log in [here](https://travis-ci.org/) and enable Travis builds for this repository.

We have to build Boost from scratch because the versions in the Ubuntu repositories are too old. We're using clang because g++ segfaults when trying to compile (yes, really).

For now, it only checks that the project compiles successfully. In the future, it could be extended to run tests and such. Travis integrates with GitHub, so you'll know when a Pull Request would break the build.

 :satellite: :rocket:
