### PR TITLE
Ignore integer part

### DIFF
--- a/src/algorithm/base.cpp
+++ b/src/algorithm/base.cpp
@@ -75,6 +75,22 @@ void base::set_screen_output(const bool p) {m_screen_output = p;}
  */
 bool base::get_screen_output() const {return m_screen_output;}
 
+/// Sets ignore integer part
+/**
+ * Sets ignore integer part boolean variable. When True the algorithm won't touch the integer part of the decision vector.
+ *
+ * @param[in] p true or false
+ */
+void base::set_ignore_integer_part(const bool p) {m_ignore_integer_part = p;}
+
+/// Gets ignore integer part
+/**
+ * Gets ignore integer part boolean variable. When True the algorithm won't touch the integer part of the decision vector.
+ *
+ * return boolean value associated to the ignore integer part option
+ */
+bool base::get_ignore_integer_part() const {return m_ignore_integer_part;}
+
 /// Resets the random number generators
 /**
  * Resets the seed of the internal random number generators to p

--- a/src/algorithm/base.cpp
+++ b/src/algorithm/base.cpp
@@ -68,7 +68,7 @@ void base::set_screen_output(const bool p) {m_screen_output = p;}
 
 /// Gets screen output
 /**
- * Gets screen output boolean variable. When True the algorithm may print stuff on screen 
+ * Gets screen output boolean variable. When True the algorithm may print stuff on screen
  * (careful, in multithreading this can mess up things)
  *
  * return boolean value associated to the screen output option
@@ -79,7 +79,7 @@ bool base::get_screen_output() const {return m_screen_output;}
 /**
  * Resets the seed of the internal random number generators to p
  *
- * @param[in] p the new seed. It will be used to instantiate both drng and urng 
+ * @param[in] p the new seed. It will be used to instantiate both drng and urng
  */
 void base::reset_rngs(const unsigned int p) const {
 	m_urng = rng_uint32(p);

--- a/src/algorithm/base.h
+++ b/src/algorithm/base.h
@@ -108,12 +108,18 @@ return base_ptr(new derived_algorithm(*this));
 		void set_screen_output(const bool p);
 		bool get_screen_output() const;
 
+		/// Setter-Getter for protected m_ignore_integer_part
+		void set_ignore_integer_part(bool);
+		bool get_ignore_integer_part() const;
+
 		/// Resets the seed of the internal rngs using a user-provided seed
 		void reset_rngs(const unsigned int) const;
 
 	protected:
 		/// Indicates to the derived class whether to print stuff on screen
 		bool m_screen_output;
+		/// Should the integer part of the decision vector be ignored
+		bool m_ignore_integer_part = false;
 		/// Random number generator for double-precision floating point values.
 		mutable rng_double	m_drng;
 		/// Random number generator for unsigned integer values.
@@ -121,11 +127,14 @@ return base_ptr(new derived_algorithm(*this));
 	private:
 		friend class boost::serialization::access;
 		template <class Archive>
-		void serialize(Archive &ar, const unsigned int)
+		void serialize(Archive &ar, const unsigned int version)
 		{
 			ar & m_drng;
 			ar & m_urng;
 			ar & m_screen_output;
+			if (version > 0) {
+				ar & m_ignore_integer_part;
+			}
 		}
 	protected:
 		/// A counter for the number of function evaluations
@@ -137,6 +146,7 @@ std::ostream __PAGMO_VISIBLE_FUNC &operator<<(std::ostream &, const base &);
 }
 }
 
+BOOST_CLASS_VERSION(pagmo::algorithm::base, 1)
 BOOST_SERIALIZATION_ASSUME_ABSTRACT(pagmo::algorithm::base)
 
 #endif

--- a/src/algorithm/base.h
+++ b/src/algorithm/base.h
@@ -56,7 +56,7 @@ typedef boost::shared_ptr<base> base_ptr;
  *
  * \section Serialization
  * The algorithm classes are serialized for the purpose of being transmitted over a distributed environment.
- * Serializing a derived algorithm requires that the needed serialization libraries be declared in their header of the derived class. 
+ * Serializing a derived algorithm requires that the needed serialization libraries be declared in their header of the derived class.
  * Virtually all the derived algorithm classes need to have the following declared in the header files:
 @verbatim
 	friend class boost::serialization::access;
@@ -66,20 +66,20 @@ typedef boost::shared_ptr<base> base_ptr;
 @verbatim
 	ar & boost::serialization::base_object<base>(*this);
 @endverbatim
- * and the rest of the attributes simply as archive members: 
+ * and the rest of the attributes simply as archive members:
 @verbatim
 	ar & attribute_name;
 @endverbatim
  * In order to be able to identify the dervied class from a base_pointer the derived class needs to be registered. This is done by registering the class in the "pagmo/src/algorithms.h", in the REGISTER_ALGORITHM_SERIALIZATIONS() routine.
- * Notes: 
+ * Notes:
  * - "const" attributes need to be cast as constants in the serialize method using const_cast
  * - attributes that that are not primitives, need be a serialized type as well
  * - pointers to primitives cannot be serialized (in this case one can split the serialize method into save/load methods and store the values, that the pointers refer to, into temporary variables which are serialized insted - see boost serialize documentation on the topic if needed)
  *
- * @author Francesco Biscani (bluescarni@gmail.com) 
+ * @author Francesco Biscani (bluescarni@gmail.com)
  */
 class __PAGMO_VISIBLE base
-{    
+{
 	public:
 		base();
 		/// Evolve method.
@@ -124,7 +124,7 @@ return base_ptr(new derived_algorithm(*this));
 		void serialize(Archive &ar, const unsigned int)
 		{
 			ar & m_drng;
-			ar & m_urng; 
+			ar & m_urng;
 			ar & m_screen_output;
 		}
 	protected:

--- a/src/algorithm/worhp.cpp
+++ b/src/algorithm/worhp.cpp
@@ -26,7 +26,7 @@
 namespace pagmo { namespace algorithm {
 
 // Dummy print function used to suppress all screen output
-void no_screen_output (int, const char []) {} 
+void no_screen_output (int, const char []) {}
 void default_output(int mode, const char *message) {
   if (mode & WORHP_PRINT_MESSAGE) {
     printf(" %s\n",message);
@@ -166,7 +166,7 @@ void worhp::evolve(pagmo::population& pop) const {
 	// Define HM as a diagonal LT-CS-matrix, but only if needed by WORHP
 	// Not sure if this is needed at all
 	if (workspace.HM.NeedStructure) {
-		for(int i = 0; i < workspace.HM.nnz; ++i) 
+		for(int i = 0; i < workspace.HM.nnz; ++i)
 		{
 			workspace.HM.row[i] = i + 1;
 			workspace.HM.col[i] = i + 1;
@@ -178,13 +178,13 @@ void worhp::evolve(pagmo::population& pop) const {
 			Worhp(&opt, &workspace, &params, &control);
 		}
 
-		if (GetUserAction(&control, iterOutput)) 
+		if (GetUserAction(&control, iterOutput))
 		{
 			IterationOutput(&opt, &workspace, &params, &control);
 			DoneUserAction(&control, iterOutput);
 		}
 
-		
+
 		if (GetUserAction(&control, evalF)) {
 			for (int i = 0; i < opt.n; ++i) {
 				x[i] = opt.X[i];

--- a/src/algorithm/worhp.cpp
+++ b/src/algorithm/worhp.cpp
@@ -90,7 +90,7 @@ void worhp::evolve(pagmo::population& pop) const {
 
 	const auto& prob = pop.problem();
 
-	if (prob.get_i_dimension() != 0) {
+	if (prob.get_i_dimension() != 0 && !m_ignore_integer_part) {
 		pagmo_throw(value_error,
 		            "The problem has an integer part and WORHP is not suitable to solve it.");
 	}
@@ -118,7 +118,7 @@ void worhp::evolve(pagmo::population& pop) const {
 	workspace.initialised = false;
 
 
-	opt.n = prob.get_dimension(); // number of variables
+	opt.n = prob.get_dimension() - prob.get_i_dimension(); // number of variables
 	opt.m = prob.get_c_dimension(); // number of constraints
 	auto n_eq = prob.get_c_dimension() - prob.get_ic_dimension(); // number of equality constraints
 


### PR DESCRIPTION
This adds a new variable called `m_ignore_integer_part` to algorithm::base. When true, the algorithm solves the problem, even if it can't do anything about the integer part of the problem.

The reason that something like this is needed, is that for a branch and bound meta-algorithm used with a mixed-integer optimization problem the integer variables sometimes need to be set and a SQP-solver (like WORHP) shouldn't throw an exception (it should just ignore them).


I'm not quite sure if this is the way to go. At the moment only WORHP reads the variable and acts on it, all other algorithm ignore it. So no problem if this doesn't get merged, just wanted to hear your thoughts on it and what do you think should be done to handle the issue explained above. Thanks :)