### PR TITLE
First attempt at fixing the includes for MinGW64.

### DIFF
--- a/PyGMO/algorithm/algorithm.cpp
+++ b/PyGMO/algorithm/algorithm.cpp
@@ -22,6 +22,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.               *
  *****************************************************************************/
 
+#include <cmath>
 #include <Python.h>
 #include <boost/python/class.hpp>
 #include <boost/python/module.hpp>

--- a/PyGMO/core/core.cpp
+++ b/PyGMO/core/core.cpp
@@ -22,6 +22,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.               *
  *****************************************************************************/
 
+#include <cmath>
 #include <Python.h>
 #include <boost/numeric/conversion/cast.hpp>
 #include <boost/python/class.hpp>

--- a/PyGMO/migration/migration.cpp
+++ b/PyGMO/migration/migration.cpp
@@ -22,6 +22,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.               *
  *****************************************************************************/
 
+#include <cmath>
 #include <boost/python/class.hpp>
 #include <boost/python/enum.hpp>
 #include <boost/python/module.hpp>

--- a/PyGMO/problem/problem.cpp
+++ b/PyGMO/problem/problem.cpp
@@ -22,6 +22,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.               *
  *****************************************************************************/
 
+#include <cmath>
 #include <Python.h>
 #include <boost/python/class.hpp>
 #include <boost/python/copy_const_reference.hpp>

--- a/PyGMO/problem/problem_meta.cpp
+++ b/PyGMO/problem/problem_meta.cpp
@@ -22,6 +22,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.               *
  *****************************************************************************/
 
+#include <cmath>
 #include <Python.h>
 #include <boost/python/class.hpp>
 #include <boost/python/copy_const_reference.hpp>

--- a/PyGMO/problem/problem_space.cpp
+++ b/PyGMO/problem/problem_space.cpp
@@ -22,6 +22,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.               *
  *****************************************************************************/
 
+#include <cmath>
 #include <Python.h>
 #include <boost/python/class.hpp>
 #include <boost/python/copy_const_reference.hpp>

--- a/PyGMO/topology/topology.cpp
+++ b/PyGMO/topology/topology.cpp
@@ -22,6 +22,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.               *
  *****************************************************************************/
 
+#include <cmath>
 #include <Python.h>
 #include <boost/numeric/conversion/cast.hpp>
 #include <boost/python/class.hpp>

--- a/PyGMO/util/util.cpp
+++ b/PyGMO/util/util.cpp
@@ -22,6 +22,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.               *
  *****************************************************************************/
 
+#include <cmath>
 #include <Python.h>
 #include <boost/numeric/conversion/cast.hpp>
 #include <boost/python/class.hpp>


### PR DESCRIPTION
So there is an issue of bad interaction between the Python headers and the standard math headers. See for instance:

http://mail.python.org/pipermail/python-list/2004-March/907592.html

This shows up when compiling in MinGW64. The fix here is to include ``cmath`` **before** ``Python.h``.

However, I have some vague recollections that in Linux (and/or maybe OSX) one must actually reverse the inclusion order (first ``Python.h``, then ``cmath``). Someone should check if this is actually true, and, in such case, probably an ``#ifdef`` guard that sets the correct order on each platform should be used instead.