### PR TITLE
cmake: link pagmo static library before mandatory shared libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,7 +394,7 @@ MESSAGE(STATUS "Shared linker flags: " "${CMAKE_SHARED_LINKER_FLAGS}")
 # Link main to pagmo_static library.
 IF(BUILD_MAIN)
 	ADD_EXECUTABLE(main main.cpp)
-		TARGET_LINK_LIBRARIES(main ${MANDATORY_LIBRARIES} pagmo_static)
+		TARGET_LINK_LIBRARIES(main pagmo_static ${MANDATORY_LIBRARIES})
 ENDIF(BUILD_MAIN)
 
 IF(ENABLE_TESTS)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,42 +1,42 @@
 IF(ENABLE_GTOP_DATABASE)
 
 ADD_EXECUTABLE(hm_2_asteroids hm_2_asteroids.cpp)
-TARGET_LINK_LIBRARIES(hm_2_asteroids ${MANDATORY_LIBRARIES} pagmo_static)
+TARGET_LINK_LIBRARIES(hm_2_asteroids pagmo_static ${MANDATORY_LIBRARIES})
 
 ADD_EXECUTABLE(migrate_or_not migrate_or_not.cpp)
-TARGET_LINK_LIBRARIES(migrate_or_not ${MANDATORY_LIBRARIES} pagmo_static)
+TARGET_LINK_LIBRARIES(migrate_or_not pagmo_static ${MANDATORY_LIBRARIES})
 
 IF(ENABLE_SNOPT)
 	ADD_EXECUTABLE(gtoc_2_turin gtoc_2_turin.cpp)
-        TARGET_LINK_LIBRARIES(gtoc_2_turin ${MANDATORY_LIBRARIES} pagmo_static)
+        TARGET_LINK_LIBRARIES(gtoc_2_turin pagmo_static ${MANDATORY_LIBRARIES})
 ENDIF(ENABLE_SNOPT)
 
 ENDIF(ENABLE_GTOP_DATABASE)
 
 IF(ENABLE_GSL)
 	ADD_EXECUTABLE(evolve_spheres evolve_spheres.cpp)
-        TARGET_LINK_LIBRARIES(evolve_spheres ${MANDATORY_LIBRARIES} pagmo_static)
+        TARGET_LINK_LIBRARIES(evolve_spheres pagmo_static ${MANDATORY_LIBRARIES})
 	ADD_EXECUTABLE(evolve_spheres_racing evolve_spheres_racing.cpp)
-        TARGET_LINK_LIBRARIES(evolve_spheres_racing ${MANDATORY_LIBRARIES} pagmo_static)
+        TARGET_LINK_LIBRARIES(evolve_spheres_racing pagmo_static ${MANDATORY_LIBRARIES})
 ENDIF(ENABLE_GSL)
 
 ADD_EXECUTABLE(constraints_handling constraints_handling.cpp)
-TARGET_LINK_LIBRARIES(constraints_handling ${MANDATORY_LIBRARIES} pagmo_static)
+TARGET_LINK_LIBRARIES(constraints_handling pagmo_static ${MANDATORY_LIBRARIES})
 
 ADD_EXECUTABLE(cstrs_death_penalty cstrs_death_penalty.cpp)
-TARGET_LINK_LIBRARIES(cstrs_death_penalty ${MANDATORY_LIBRARIES} pagmo_static)
+TARGET_LINK_LIBRARIES(cstrs_death_penalty pagmo_static ${MANDATORY_LIBRARIES})
 
 ADD_EXECUTABLE(cstrs_co_evolution cstrs_co_evolution.cpp)
-TARGET_LINK_LIBRARIES(cstrs_co_evolution ${MANDATORY_LIBRARIES} pagmo_static)
+TARGET_LINK_LIBRARIES(cstrs_co_evolution pagmo_static ${MANDATORY_LIBRARIES})
 
 ADD_EXECUTABLE(cstrs_self_adaptive cstrs_self_adaptive.cpp)
-TARGET_LINK_LIBRARIES(cstrs_self_adaptive ${MANDATORY_LIBRARIES} pagmo_static)
+TARGET_LINK_LIBRARIES(cstrs_self_adaptive pagmo_static ${MANDATORY_LIBRARIES})
 
 ADD_EXECUTABLE(cstrs_self_adaptive_island cstrs_self_adaptive_island.cpp)
-TARGET_LINK_LIBRARIES(cstrs_self_adaptive_island ${MANDATORY_LIBRARIES} pagmo_static)
+TARGET_LINK_LIBRARIES(cstrs_self_adaptive_island pagmo_static ${MANDATORY_LIBRARIES})
 
 ADD_EXECUTABLE(cstrs_immune_system cstrs_immune_system.cpp)
-TARGET_LINK_LIBRARIES(cstrs_immune_system ${MANDATORY_LIBRARIES} pagmo_static)
+TARGET_LINK_LIBRARIES(cstrs_immune_system pagmo_static ${MANDATORY_LIBRARIES})
 
 ADD_EXECUTABLE(cstrs_core cstrs_core.cpp)
-TARGET_LINK_LIBRARIES(cstrs_core ${MANDATORY_LIBRARIES} pagmo_static)
+TARGET_LINK_LIBRARIES(cstrs_core pagmo_static ${MANDATORY_LIBRARIES})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,66 +1,66 @@
 ADD_EXECUTABLE(best_solutions_test best_solutions_test.cpp)
-TARGET_LINK_LIBRARIES(best_solutions_test ${MANDATORY_LIBRARIES} pagmo_static)
+TARGET_LINK_LIBRARIES(best_solutions_test pagmo_static ${MANDATORY_LIBRARIES})
 ADD_TEST(best_solutions_test best_solutions_test)
 
 ADD_EXECUTABLE(local_torture_test local_torture_test.cpp)
-TARGET_LINK_LIBRARIES(local_torture_test ${MANDATORY_LIBRARIES} pagmo_static)
+TARGET_LINK_LIBRARIES(local_torture_test pagmo_static ${MANDATORY_LIBRARIES})
 ADD_TEST(local_torture_test local_torture_test)
 
 ADD_EXECUTABLE(serialization_problems serialization_problems.cpp)
-TARGET_LINK_LIBRARIES(serialization_problems ${MANDATORY_LIBRARIES} pagmo_static)
+TARGET_LINK_LIBRARIES(serialization_problems pagmo_static ${MANDATORY_LIBRARIES})
 ADD_TEST(serialization_problems serialization_problems)
 
 ADD_EXECUTABLE(serialization_algorithms serialization_algorithms.cpp)
-TARGET_LINK_LIBRARIES(serialization_algorithms ${MANDATORY_LIBRARIES} pagmo_static)
+TARGET_LINK_LIBRARIES(serialization_algorithms pagmo_static ${MANDATORY_LIBRARIES})
 ADD_TEST(serialization_algorithms serialization_algorithms)
 
 ADD_EXECUTABLE(test_shifted test_shifted.cpp)
-TARGET_LINK_LIBRARIES(test_shifted ${MANDATORY_LIBRARIES} pagmo_static)
+TARGET_LINK_LIBRARIES(test_shifted pagmo_static ${MANDATORY_LIBRARIES})
 ADD_TEST(test_shifted test_shifted)
 
 ADD_EXECUTABLE(test_rotated test_rotated.cpp)
-TARGET_LINK_LIBRARIES(test_rotated ${MANDATORY_LIBRARIES} pagmo_static)
+TARGET_LINK_LIBRARIES(test_rotated pagmo_static ${MANDATORY_LIBRARIES})
 ADD_TEST(test_rotated test_rotated)
 
 ADD_EXECUTABLE(test_noisy test_noisy.cpp)
-TARGET_LINK_LIBRARIES(test_noisy ${MANDATORY_LIBRARIES} pagmo_static)
+TARGET_LINK_LIBRARIES(test_noisy pagmo_static ${MANDATORY_LIBRARIES})
 ADD_TEST(test_noisy test_noisy)
 
 ADD_EXECUTABLE(hypervolume_test hypervolume_test.cpp)
-TARGET_LINK_LIBRARIES(hypervolume_test ${MANDATORY_LIBRARIES} pagmo_static)
+TARGET_LINK_LIBRARIES(hypervolume_test pagmo_static ${MANDATORY_LIBRARIES})
 ADD_TEST(hypervolume_test hypervolume_test)
 
 ADD_EXECUTABLE(serialization_hypervolume serialization_hypervolume.cpp)
-TARGET_LINK_LIBRARIES(serialization_hypervolume ${MANDATORY_LIBRARIES} pagmo_static)
+TARGET_LINK_LIBRARIES(serialization_hypervolume pagmo_static ${MANDATORY_LIBRARIES})
 ADD_TEST(serialization_hypervolume serialization_hypervolume)
 
 ADD_EXECUTABLE(test_robust test_robust.cpp)
-TARGET_LINK_LIBRARIES(test_robust ${MANDATORY_LIBRARIES} pagmo_static)
+TARGET_LINK_LIBRARIES(test_robust pagmo_static ${MANDATORY_LIBRARIES})
 ADD_TEST(test_robust test_robust)
 
 ADD_EXECUTABLE(test_racing test_racing.cpp)
-TARGET_LINK_LIBRARIES(test_racing ${MANDATORY_LIBRARIES} pagmo_static)
+TARGET_LINK_LIBRARIES(test_racing pagmo_static ${MANDATORY_LIBRARIES})
 ADD_TEST(test_racing test_racing)
 
 ADD_EXECUTABLE(test_racing_algorithm test_racing_algorithm.cpp)
-TARGET_LINK_LIBRARIES(test_racing_algorithm ${MANDATORY_LIBRARIES} pagmo_static)
+TARGET_LINK_LIBRARIES(test_racing_algorithm pagmo_static ${MANDATORY_LIBRARIES})
 ADD_TEST(test_racing_algorithm test_racing_algorithm)
 
 ADD_EXECUTABLE(test_tsp test_tsp.cpp)
-TARGET_LINK_LIBRARIES(test_tsp ${MANDATORY_LIBRARIES} pagmo_static)
+TARGET_LINK_LIBRARIES(test_tsp pagmo_static ${MANDATORY_LIBRARIES})
 ADD_TEST(test_tsp test_tsp)
 
 ADD_EXECUTABLE(test_archipelago test_archipelago.cpp)
-TARGET_LINK_LIBRARIES(test_archipelago ${MANDATORY_LIBRARIES} pagmo_static)
+TARGET_LINK_LIBRARIES(test_archipelago pagmo_static ${MANDATORY_LIBRARIES})
 ADD_TEST(test_archipelago test_archipelago)
 
 ADD_EXECUTABLE(test_decompose test_decompose.cpp)
-TARGET_LINK_LIBRARIES(test_decompose ${MANDATORY_LIBRARIES} pagmo_static)
+TARGET_LINK_LIBRARIES(test_decompose pagmo_static ${MANDATORY_LIBRARIES})
 ADD_TEST(test_decompose test_decompose)
 
 IF(ENABLE_MPI)
 	ADD_EXECUTABLE(mpi_torture_test mpi_torture_test.cpp)
-        TARGET_LINK_LIBRARIES(mpi_torture_test ${MANDATORY_LIBRARIES} pagmo_static)
+        TARGET_LINK_LIBRARIES(mpi_torture_test pagmo_static ${MANDATORY_LIBRARIES})
 	ADD_TEST(mpi_torture_test_01 ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 10 ${MPIEXEC_PREFLAGS} ./mpi_torture_test
 		${MPIEXEC_POSTFLAGS})
 	ADD_TEST(mpi_torture_test_02 ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_PREFLAGS} ./mpi_torture_test


### PR DESCRIPTION
Fixes #174. The old link order resulted in a long series of unresolved
symbol errors on some platforms. Since the linker looks for unresolved
symbols from left to right, we link the static library before the shared
ones.

Tested on the following docker images ubuntu:16.04,
base/archlinux:latest, fedora:latest.
