### PR TITLE
A way of using ipy_island based on ipyparallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ install:
   - tar -xjf boost.tar.bz2
   - rm boost.tar.bz2
   - export BOOST_ROOT=$(pwd)/boost
+  - pip install --user ipyparallel
 
 script:
   - mkdir build
@@ -44,6 +45,7 @@ script:
   - make install
   - export PYTHONPATH=~/local/python
   - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:~/local/lib:${PWD%/build}/boost/lib
+  - pip install ipyparallel
   - python -c "from PyGMO import test; test.run_full_test_suite()"
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,6 @@ script:
   - make install
   - export PYTHONPATH=~/local/python
   - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:~/local/lib:${PWD%/build}/boost/lib
-  - pip install ipyparallel
   - python -c "from PyGMO import test; test.run_full_test_suite()"
 
 after_success:

--- a/PyGMO/test/__init__.py
+++ b/PyGMO/test/__init__.py
@@ -90,12 +90,11 @@ class _island_torture_test(_ut.TestCase):
 
     def test_ipy_island(self):
         from PyGMO import ipy_island, algorithm, problem
-        try:
-            from IPython.kernel import client
-            mec = client.MultiEngineClient()
-            if len(mec) == 0:
+        try: 
+            from ipyparallel import Client
+            rc = Client()
+            if len(rc.ids) == 0:
                 raise RuntimeError()
-        except ImportError as ie:
             return
         except BaseException as e:
             print(
@@ -103,6 +102,7 @@ class _island_torture_test(_ut.TestCase):
             print(e)
             print('Tests for ipy_island will not be run.')
             return
+        
         isl_type = ipy_island
         algo_list = [algorithm.py_example(1), algorithm.de(5)]
         prob_list = [problem.py_example(), problem.dejong(1)]


### PR DESCRIPTION
The existing `ipy_island` depends on `IPython.kernel.TaskClient` and `MapTask`, which are deprecated, and even not available in the recent ipython support. Therefore, the following warning message can be encountered.

```
.../lib/python2.7/site-packages/IPython/kernel/__init__.py:13: ShimWarning: 
The `IPython.kernel` package has been deprecated.
You should import from ipykernel or jupyter_client instead. 
```

I modified this part based on `ipyparallel`, which provides `ipyparallel.Client` and `View` for the ipython multiprocessing. Review my commit to check whether it is appropriate, please.